### PR TITLE
Add per-user OAuth flow for Slack MCP tokens with Neon/Drizzle storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Slack App Credentials (from api.slack.com > Your App > Basic Information)
+SLACK_BOT_TOKEN=xoxb-...
+SLACK_SIGNING_SECRET=...
+
+# OAuth (from api.slack.com > Your App > Basic Information > App Credentials)
+# Required for per-user MCP token authorization
+SLACK_CLIENT_ID=...
+SLACK_CLIENT_SECRET=...
+SLACK_STATE_SECRET=replace-with-a-random-secret-string
+
+# Optional: Override the base URL for OAuth redirects (e.g., your ngrok tunnel URL)
+# If not set, uses VERCEL_PROJECT_PRODUCTION_URL or VERCEL_URL automatically
+# SLACK_OAUTH_REDIRECT_URL=https://your-app-domain.com
+
+# Neon PostgreSQL (for storing user OAuth tokens)
+DATABASE_URL=postgresql://...

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  schema: "./server/lib/db/schema.ts",
+  out: "./drizzle",
+  dialect: "postgresql",
+  dbCredentials: {
+    url: process.env.DATABASE_URL!,
+  },
+});

--- a/manifest.json
+++ b/manifest.json
@@ -34,6 +34,9 @@
     }
   },
   "oauth_config": {
+    "redirect_urls": [
+      "https://your-app-domain.com/slack/oauth_redirect"
+    ],
     "scopes": {
       "bot": [
         "channels:history",
@@ -47,6 +50,26 @@
         "assistant:write",
         "reactions:write",
         "channels:join"
+      ],
+      "user": [
+        "search:read",
+        "channels:history",
+        "channels:read",
+        "groups:history",
+        "groups:read",
+        "mpim:history",
+        "mpim:read",
+        "im:history",
+        "im:read",
+        "users:read",
+        "users:read.email",
+        "chat:write",
+        "canvases:read",
+        "canvases:write",
+        "files:read",
+        "reactions:read",
+        "team:read",
+        "usergroups:read"
       ]
     }
   },

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@ai-sdk/mcp": "^0.10.0",
     "@slack/bolt": "^4.6.0",
     "@slack/web-api": "^7.13.0",
     "@vercel/slack-bolt": "latest",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "license": "MIT",
   "scripts": {
     "build": "nitro build",
+    "db:push": "drizzle-kit push",
+    "db:studio": "drizzle-kit studio",
     "dev": "nitro dev",
     "dev:tunnel": "tsx scripts/dev.tunnel.ts",
     "configure": "tsx scripts/configure.ts",
@@ -17,16 +19,19 @@
   },
   "dependencies": {
     "@ai-sdk/mcp": "^0.10.0",
+    "@neondatabase/serverless": "^0.10.0",
     "@slack/bolt": "^4.6.0",
     "@slack/web-api": "^7.13.0",
     "@vercel/slack-bolt": "latest",
     "@workflow/ai": "4.0.1-beta.44",
     "ai": "^6.0.27",
+    "drizzle-orm": "^0.44.0",
     "workflow": "4.0.1-beta.44",
     "zod": "^4.3.5"
   },
   "devDependencies": {
     "@biomejs/biome": "2.2.6",
+    "drizzle-kit": "^0.31.0",
     "@inquirer/input": "^4.3.1",
     "@ngrok/ngrok": "^1.7.0",
     "@slack/cli-hooks": "^1.2.1",

--- a/server/lib/ai/agent.ts
+++ b/server/lib/ai/agent.ts
@@ -1,9 +1,11 @@
+import type { ToolSet } from "ai";
 import { DurableAgent } from "@workflow/ai/agent";
 import type { SlackAgentContextInput } from "./context";
 import { slackTools } from "./tools";
 
 export const createSlackAgent = (
-  context: SlackAgentContextInput
+  context: SlackAgentContextInput,
+  mcpTools?: ToolSet
 ): DurableAgent => {
   const { channel_id, dm_channel, thread_ts, is_dm, team_id } = context;
 
@@ -54,7 +56,18 @@ ${channelContextSection}
 ${joinChannelsSection}
 - **Searching channels**: When the user asks about a channel by name (e.g., "tell me about the marketing channel", "what is #engineering for?", "find channels about design"), use searchChannels with team_id="${team_id}". This returns channel details including purpose, topic, and member count.
 
-### 4. Responding
+### 4. Slack MCP Tools
+${
+  mcpTools
+    ? `- You have access to additional Slack MCP tools (prefixed with "slack_") for posting messages, adding reactions, getting user profiles, and more.
+- Use slack_post_message to send messages to channels, slack_reply_to_thread to reply in threads, slack_add_reaction to react to messages.
+- Use slack_get_users and slack_get_user_profile to look up user information.
+- Use slack_get_channel_history and slack_get_thread_replies for additional context gathering.
+- Use slack_list_channels to discover available channels.`
+    : "- Slack MCP tools are not currently available."
+}
+
+### 5. Responding
 - Answer clearly and helpfully after fetching context.
 - Suggest next steps if needed; avoid unnecessary clarifying questions.
 - Slack markdown doesn't support language tags in code blocks.
@@ -77,6 +90,9 @@ Message received
   │
   └─ End
 `,
-    tools: slackTools,
+    tools: {
+      ...slackTools,
+      ...(mcpTools ?? {}),
+    },
   });
 };

--- a/server/lib/ai/agent.ts
+++ b/server/lib/ai/agent.ts
@@ -59,11 +59,11 @@ ${joinChannelsSection}
 ### 4. Slack MCP Tools
 ${
   mcpTools
-    ? `- You have access to additional Slack MCP tools (prefixed with "slack_") for posting messages, adding reactions, getting user profiles, and more.
-- Use slack_post_message to send messages to channels, slack_reply_to_thread to reply in threads, slack_add_reaction to react to messages.
-- Use slack_get_users and slack_get_user_profile to look up user information.
-- Use slack_get_channel_history and slack_get_thread_replies for additional context gathering.
-- Use slack_list_channels to discover available channels.`
+    ? `- You have access to additional tools from Slack's official MCP server (https://mcp.slack.com/mcp).
+- These tools can search channels, messages, files, and users across the workspace.
+- They can also send messages, read threads/channel history, and manage canvases.
+- Use these MCP tools to complement your built-in tools — they act on behalf of the authenticated user.
+- Prefer MCP tools for searching (messages, files, users) since they provide richer results than the built-in tools.`
     : "- Slack MCP tools are not currently available."
 }
 

--- a/server/lib/ai/context.ts
+++ b/server/lib/ai/context.ts
@@ -14,4 +14,6 @@ export type SlackAgentContextInput = {
   bot_id?: string;
   /** The Slack bot token for creating the client */
   token: string;
+  /** The user's OAuth token (xoxp-...) for Slack MCP server, if available */
+  userToken?: string;
 };

--- a/server/lib/ai/mcp.ts
+++ b/server/lib/ai/mcp.ts
@@ -1,49 +1,44 @@
 import { createMCPClient } from "@ai-sdk/mcp";
-import { Experimental_StdioMCPTransport } from "@ai-sdk/mcp/mcp-stdio";
 
 export type MCPClientInstance = Awaited<ReturnType<typeof createMCPClient>>;
 
 /**
- * Creates a Slack MCP client using the official @modelcontextprotocol/server-slack package.
+ * Creates a client for Slack's official MCP server at https://mcp.slack.com/mcp
  *
- * This uses stdio transport to communicate with the Slack MCP server subprocess.
- * The server provides tools like slack_list_channels, slack_post_message,
- * slack_reply_to_thread, slack_add_reaction, slack_get_channel_history,
- * slack_get_thread_replies, slack_get_users, and slack_get_user_profile.
+ * Uses the Streamable HTTP transport (JSON-RPC 2.0 over HTTP) — works in serverless
+ * environments like Vercel since there's no subprocess or persistent connection needed.
+ *
+ * The server provides tools for searching channels/messages/users, sending messages,
+ * managing canvases, reading threads and channel history, and more.
+ *
+ * @see https://docs.slack.dev/ai/slack-mcp-server/
  *
  * Required env vars:
- * - SLACK_BOT_TOKEN: The Bot User OAuth Token (xoxb-...)
- * - SLACK_TEAM_ID: The workspace team ID (T...)
+ * - SLACK_MCP_USER_TOKEN: A Slack user OAuth token (xoxp-...) with the appropriate
+ *   scopes for the MCP tools you want to use. See the Slack MCP docs for required scopes.
  *
  * @returns The MCP client instance (must be closed after use)
  */
 export async function createSlackMCPClient(): Promise<MCPClientInstance> {
-  const token = process.env.SLACK_BOT_TOKEN;
-  const teamId = process.env.SLACK_TEAM_ID;
+  const userToken = process.env.SLACK_MCP_USER_TOKEN;
 
-  if (!token) {
+  if (!userToken) {
     throw new Error(
-      "SLACK_BOT_TOKEN is required to start the Slack MCP server"
+      "SLACK_MCP_USER_TOKEN is required to connect to Slack's MCP server. " +
+        "This must be a user OAuth token (xoxp-...) with the appropriate scopes. " +
+        "See https://docs.slack.dev/ai/slack-mcp-server/ for details."
     );
   }
-  if (!teamId) {
-    throw new Error("SLACK_TEAM_ID is required to start the Slack MCP server");
-  }
-
-  const transport = new Experimental_StdioMCPTransport({
-    command: "npx",
-    args: ["-y", "@modelcontextprotocol/server-slack"],
-    env: {
-      SLACK_BOT_TOKEN: token,
-      SLACK_TEAM_ID: teamId,
-      // Pass through PATH so npx can find node
-      PATH: process.env.PATH ?? "",
-    },
-  });
 
   const client = await createMCPClient({
-    transport,
-    name: "slack-agent-mcp-client",
+    transport: {
+      type: "http",
+      url: "https://mcp.slack.com/mcp",
+      headers: {
+        Authorization: `Bearer ${userToken}`,
+      },
+    },
+    name: "slack-mcp-client",
   });
 
   return client;

--- a/server/lib/ai/mcp.ts
+++ b/server/lib/ai/mcp.ts
@@ -13,22 +13,12 @@ export type MCPClientInstance = Awaited<ReturnType<typeof createMCPClient>>;
  *
  * @see https://docs.slack.dev/ai/slack-mcp-server/
  *
- * Required env vars:
- * - SLACK_MCP_USER_TOKEN: A Slack user OAuth token (xoxp-...) with the appropriate
- *   scopes for the MCP tools you want to use. See the Slack MCP docs for required scopes.
- *
+ * @param userToken - A Slack user OAuth token (xoxp-...) obtained via the OAuth flow.
  * @returns The MCP client instance (must be closed after use)
  */
-export async function createSlackMCPClient(): Promise<MCPClientInstance> {
-  const userToken = process.env.SLACK_MCP_USER_TOKEN;
-
-  if (!userToken) {
-    throw new Error(
-      "SLACK_MCP_USER_TOKEN is required to connect to Slack's MCP server. " +
-        "This must be a user OAuth token (xoxp-...) with the appropriate scopes. " +
-        "See https://docs.slack.dev/ai/slack-mcp-server/ for details."
-    );
-  }
+export async function createSlackMCPClient(
+  userToken: string
+): Promise<MCPClientInstance> {
 
   const client = await createMCPClient({
     transport: {

--- a/server/lib/ai/mcp.ts
+++ b/server/lib/ai/mcp.ts
@@ -1,0 +1,58 @@
+import { createMCPClient } from "@ai-sdk/mcp";
+import { Experimental_StdioMCPTransport } from "@ai-sdk/mcp/mcp-stdio";
+
+export type MCPClientInstance = Awaited<ReturnType<typeof createMCPClient>>;
+
+/**
+ * Creates a Slack MCP client using the official @modelcontextprotocol/server-slack package.
+ *
+ * This uses stdio transport to communicate with the Slack MCP server subprocess.
+ * The server provides tools like slack_list_channels, slack_post_message,
+ * slack_reply_to_thread, slack_add_reaction, slack_get_channel_history,
+ * slack_get_thread_replies, slack_get_users, and slack_get_user_profile.
+ *
+ * Required env vars:
+ * - SLACK_BOT_TOKEN: The Bot User OAuth Token (xoxb-...)
+ * - SLACK_TEAM_ID: The workspace team ID (T...)
+ *
+ * @returns The MCP client instance (must be closed after use)
+ */
+export async function createSlackMCPClient(): Promise<MCPClientInstance> {
+  const token = process.env.SLACK_BOT_TOKEN;
+  const teamId = process.env.SLACK_TEAM_ID;
+
+  if (!token) {
+    throw new Error(
+      "SLACK_BOT_TOKEN is required to start the Slack MCP server"
+    );
+  }
+  if (!teamId) {
+    throw new Error("SLACK_TEAM_ID is required to start the Slack MCP server");
+  }
+
+  const transport = new Experimental_StdioMCPTransport({
+    command: "npx",
+    args: ["-y", "@modelcontextprotocol/server-slack"],
+    env: {
+      SLACK_BOT_TOKEN: token,
+      SLACK_TEAM_ID: teamId,
+      // Pass through PATH so npx can find node
+      PATH: process.env.PATH ?? "",
+    },
+  });
+
+  const client = await createMCPClient({
+    transport,
+    name: "slack-agent-mcp-client",
+  });
+
+  return client;
+}
+
+/**
+ * Gets tools from a Slack MCP client instance.
+ * Returns an object of AI SDK tool definitions that can be spread into an agent's tools.
+ */
+export async function getSlackMCPTools(client: MCPClientInstance) {
+  return await client.tools();
+}

--- a/server/lib/ai/workflows/chat.ts
+++ b/server/lib/ai/workflows/chat.ts
@@ -16,13 +16,13 @@ export async function chatWorkflow(
 
   const writable = getWritable<UIMessageChunk>();
 
-  // Initialize MCP client for Slack's official MCP server (if user token is configured)
+  // Initialize MCP client for Slack's official MCP server (if user has authorized via OAuth)
   let mcpClient: MCPClientInstance | undefined;
   let mcpTools: ToolSet | undefined;
 
-  if (process.env.SLACK_MCP_USER_TOKEN) {
+  if (context.userToken) {
     try {
-      mcpClient = await createSlackMCPClient();
+      mcpClient = await createSlackMCPClient(context.userToken);
       mcpTools = await getSlackMCPTools(mcpClient);
     } catch (error) {
       console.warn("Failed to initialize Slack MCP client:", error);

--- a/server/lib/ai/workflows/chat.ts
+++ b/server/lib/ai/workflows/chat.ts
@@ -16,11 +16,11 @@ export async function chatWorkflow(
 
   const writable = getWritable<UIMessageChunk>();
 
-  // Initialize MCP client for Slack MCP tools (if SLACK_TEAM_ID is configured)
+  // Initialize MCP client for Slack's official MCP server (if user token is configured)
   let mcpClient: MCPClientInstance | undefined;
   let mcpTools: ToolSet | undefined;
 
-  if (process.env.SLACK_TEAM_ID) {
+  if (process.env.SLACK_MCP_USER_TOKEN) {
     try {
       mcpClient = await createSlackMCPClient();
       mcpTools = await getSlackMCPTools(mcpClient);
@@ -40,7 +40,7 @@ export async function chatWorkflow(
       experimental_context: context,
     });
   } finally {
-    // Always close the MCP client to clean up the subprocess
+    // Always close the MCP client to clean up the HTTP session
     if (mcpClient) {
       try {
         await mcpClient.close();

--- a/server/lib/ai/workflows/chat.ts
+++ b/server/lib/ai/workflows/chat.ts
@@ -1,21 +1,52 @@
-import type { ModelMessage, UIMessageChunk } from "ai";
+import type { ModelMessage, ToolSet, UIMessageChunk } from "ai";
 import { getWritable } from "workflow";
 import { createSlackAgent } from "~/lib/ai/agent";
 import type { SlackAgentContextInput } from "~/lib/ai/context";
+import {
+  createSlackMCPClient,
+  getSlackMCPTools,
+  type MCPClientInstance,
+} from "~/lib/ai/mcp";
 
 export async function chatWorkflow(
   messages: ModelMessage[],
-  context: SlackAgentContextInput,
+  context: SlackAgentContextInput
 ) {
   "use workflow";
 
   const writable = getWritable<UIMessageChunk>();
-  const agent = createSlackAgent(context);
 
-  await agent.stream({
-    messages,
-    writable,
-    // Pass context to tools via experimental_context (client created inside steps)
-    experimental_context: context,
-  });
+  // Initialize MCP client for Slack MCP tools (if SLACK_TEAM_ID is configured)
+  let mcpClient: MCPClientInstance | undefined;
+  let mcpTools: ToolSet | undefined;
+
+  if (process.env.SLACK_TEAM_ID) {
+    try {
+      mcpClient = await createSlackMCPClient();
+      mcpTools = await getSlackMCPTools(mcpClient);
+    } catch (error) {
+      console.warn("Failed to initialize Slack MCP client:", error);
+      // Continue without MCP tools — the built-in tools still work
+    }
+  }
+
+  try {
+    const agent = createSlackAgent(context, mcpTools);
+
+    await agent.stream({
+      messages,
+      writable,
+      // Pass context to tools via experimental_context (client created inside steps)
+      experimental_context: context,
+    });
+  } finally {
+    // Always close the MCP client to clean up the subprocess
+    if (mcpClient) {
+      try {
+        await mcpClient.close();
+      } catch {
+        // Ignore close errors
+      }
+    }
+  }
 }

--- a/server/lib/db/index.ts
+++ b/server/lib/db/index.ts
@@ -1,0 +1,7 @@
+import { neon } from "@neondatabase/serverless";
+import { drizzle } from "drizzle-orm/neon-http";
+import * as schema from "./schema";
+
+const sql = neon(process.env.DATABASE_URL!);
+
+export const db = drizzle({ client: sql, schema });

--- a/server/lib/db/schema.ts
+++ b/server/lib/db/schema.ts
@@ -1,0 +1,33 @@
+import { pgTable, text, timestamp, primaryKey } from "drizzle-orm/pg-core";
+
+/**
+ * Stores Slack OAuth installations per team+user.
+ *
+ * Each row represents one user's OAuth grant in a specific workspace.
+ * The `user_token` is the `xoxp-...` token used to authenticate with
+ * Slack's MCP server on behalf of that user.
+ */
+export const slackInstallations = pgTable(
+  "slack_installations",
+  {
+    teamId: text("team_id").notNull(),
+    userId: text("user_id").notNull(),
+    userToken: text("user_token").notNull(),
+    /** Optional: store the bot token from the same installation */
+    botToken: text("bot_token"),
+    /** Scopes granted by the user */
+    userScopes: text("user_scopes"),
+    /** Slack app ID for reference */
+    appId: text("app_id"),
+    /** Enterprise org ID (for Enterprise Grid installs) */
+    enterpriseId: text("enterprise_id"),
+    /** Token type (usually "user") */
+    tokenType: text("token_type"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+  },
+  (table) => [primaryKey({ columns: [table.teamId, table.userId] })]
+);
+
+export type SlackInstallation = typeof slackInstallations.$inferSelect;
+export type NewSlackInstallation = typeof slackInstallations.$inferInsert;

--- a/server/lib/slack/installation-store.ts
+++ b/server/lib/slack/installation-store.ts
@@ -1,0 +1,79 @@
+import { eq, and } from "drizzle-orm";
+import { db } from "~/lib/db";
+import { slackInstallations } from "~/lib/db/schema";
+
+/**
+ * Retrieves the user OAuth token for a specific team + user combination.
+ * Returns the `xoxp-...` token needed for Slack's MCP server, or null if not found.
+ */
+export async function getUserToken(
+  teamId: string,
+  userId: string
+): Promise<string | null> {
+  const [installation] = await db
+    .select({ userToken: slackInstallations.userToken })
+    .from(slackInstallations)
+    .where(
+      and(
+        eq(slackInstallations.teamId, teamId),
+        eq(slackInstallations.userId, userId)
+      )
+    )
+    .limit(1);
+
+  return installation?.userToken ?? null;
+}
+
+/**
+ * Stores or updates a user's OAuth installation.
+ * Uses upsert (INSERT ... ON CONFLICT UPDATE) to handle re-authorizations.
+ */
+export async function storeInstallation(params: {
+  teamId: string;
+  userId: string;
+  userToken: string;
+  botToken?: string;
+  userScopes?: string;
+  appId?: string;
+  enterpriseId?: string;
+  tokenType?: string;
+}) {
+  await db
+    .insert(slackInstallations)
+    .values({
+      teamId: params.teamId,
+      userId: params.userId,
+      userToken: params.userToken,
+      botToken: params.botToken,
+      userScopes: params.userScopes,
+      appId: params.appId,
+      enterpriseId: params.enterpriseId,
+      tokenType: params.tokenType,
+    })
+    .onConflictDoUpdate({
+      target: [slackInstallations.teamId, slackInstallations.userId],
+      set: {
+        userToken: params.userToken,
+        botToken: params.botToken,
+        userScopes: params.userScopes,
+        appId: params.appId,
+        enterpriseId: params.enterpriseId,
+        tokenType: params.tokenType,
+        updatedAt: new Date(),
+      },
+    });
+}
+
+/**
+ * Deletes a user's OAuth installation (e.g., on app_uninstalled or tokens_revoked).
+ */
+export async function deleteInstallation(teamId: string, userId: string) {
+  await db
+    .delete(slackInstallations)
+    .where(
+      and(
+        eq(slackInstallations.teamId, teamId),
+        eq(slackInstallations.userId, userId)
+      )
+    );
+}

--- a/server/lib/slack/oauth.ts
+++ b/server/lib/slack/oauth.ts
@@ -1,0 +1,154 @@
+import crypto from "node:crypto";
+
+/**
+ * User scopes required for Slack's MCP server.
+ * @see https://docs.slack.dev/ai/slack-mcp-server/
+ */
+const MCP_USER_SCOPES = [
+  "search:read",
+  "channels:history",
+  "channels:read",
+  "groups:history",
+  "groups:read",
+  "mpim:history",
+  "mpim:read",
+  "im:history",
+  "im:read",
+  "users:read",
+  "users:read.email",
+  "chat:write",
+  "canvases:read",
+  "canvases:write",
+  "files:read",
+  "reactions:read",
+  "team:read",
+  "usergroups:read",
+];
+
+function getConfig() {
+  const clientId = process.env.SLACK_CLIENT_ID;
+  const clientSecret = process.env.SLACK_CLIENT_SECRET;
+  const stateSecret = process.env.SLACK_STATE_SECRET;
+
+  if (!clientId || !clientSecret || !stateSecret) {
+    throw new Error(
+      "Missing SLACK_CLIENT_ID, SLACK_CLIENT_SECRET, or SLACK_STATE_SECRET environment variables."
+    );
+  }
+
+  return { clientId, clientSecret, stateSecret };
+}
+
+/**
+ * Generates a signed state parameter for OAuth CSRF protection.
+ * Format: `<random>.<timestamp>.<signature>`
+ */
+export function generateOAuthState(): { state: string } {
+  const { stateSecret } = getConfig();
+  const random = crypto.randomBytes(16).toString("hex");
+  const timestamp = Date.now().toString();
+  const payload = `${random}.${timestamp}`;
+  const signature = crypto
+    .createHmac("sha256", stateSecret)
+    .update(payload)
+    .digest("hex");
+
+  return { state: `${payload}.${signature}` };
+}
+
+/**
+ * Verifies an OAuth state parameter. Returns true if valid and not expired (10 min window).
+ */
+export function verifyOAuthState(state: string): boolean {
+  const { stateSecret } = getConfig();
+  const parts = state.split(".");
+  if (parts.length !== 3) return false;
+
+  const [random, timestamp, signature] = parts;
+  const payload = `${random}.${timestamp}`;
+  const expected = crypto
+    .createHmac("sha256", stateSecret)
+    .update(payload)
+    .digest("hex");
+
+  // Constant-time comparison
+  if (
+    signature.length !== expected.length ||
+    !crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expected))
+  ) {
+    return false;
+  }
+
+  // Check expiration (10 minutes)
+  const elapsed = Date.now() - Number.parseInt(timestamp, 10);
+  if (elapsed > 10 * 60 * 1000) return false;
+
+  return true;
+}
+
+/**
+ * Builds the Slack OAuth authorization URL for user token grants.
+ */
+export function getInstallUrl(state: string): string {
+  const { clientId } = getConfig();
+  const redirectUri = `${getBaseUrl()}/slack/oauth_redirect`;
+
+  const params = new URLSearchParams({
+    client_id: clientId,
+    user_scope: MCP_USER_SCOPES.join(","),
+    state,
+    redirect_uri: redirectUri,
+  });
+
+  return `https://slack.com/oauth/v2/authorize?${params.toString()}`;
+}
+
+/**
+ * Exchanges an OAuth authorization code for tokens using Slack's oauth.v2.access endpoint.
+ */
+export async function exchangeCodeForToken(code: string): Promise<{
+  ok: boolean;
+  authed_user?: {
+    id: string;
+    scope: string;
+    access_token: string;
+    token_type: string;
+  };
+  team?: { id: string; name: string };
+  enterprise?: { id: string; name: string } | null;
+  app_id?: string;
+  error?: string;
+}> {
+  const { clientId, clientSecret } = getConfig();
+  const redirectUri = `${getBaseUrl()}/slack/oauth_redirect`;
+
+  const response = await fetch("https://slack.com/api/oauth.v2.access", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      code,
+      redirect_uri: redirectUri,
+    }),
+  });
+
+  return response.json();
+}
+
+/**
+ * Returns the base URL for OAuth redirects.
+ * Uses VERCEL_PROJECT_PRODUCTION_URL, VERCEL_URL, or falls back to localhost.
+ */
+function getBaseUrl(): string {
+  if (process.env.SLACK_OAUTH_REDIRECT_URL) {
+    return process.env.SLACK_OAUTH_REDIRECT_URL.replace(/\/$/, "");
+  }
+  if (process.env.VERCEL_PROJECT_PRODUCTION_URL) {
+    return `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`;
+  }
+  if (process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL}`;
+  }
+  return "http://localhost:3000";
+}

--- a/server/listeners/assistant/assistantThreadStarted.ts
+++ b/server/listeners/assistant/assistantThreadStarted.ts
@@ -1,4 +1,5 @@
 import type { AssistantThreadStartedMiddleware } from "@slack/bolt";
+import { getUserToken } from "~/lib/slack/installation-store";
 
 /**
  * The `assistant_thread_started` event is sent when a user opens the Assistant container.
@@ -11,10 +12,25 @@ export const assistantThreadStarted: AssistantThreadStartedMiddleware = async ({
   say,
   setSuggestedPrompts,
   saveThreadContext,
+  context: boltContext,
 }) => {
   const { context } = event.assistant_thread;
 
   try {
+    // Check if the user has authorized MCP tools via OAuth
+    let hasMcpToken = false;
+    if (boltContext.userId && boltContext.teamId) {
+      try {
+        const token = await getUserToken(
+          boltContext.teamId,
+          boltContext.userId
+        );
+        hasMcpToken = !!token;
+      } catch {
+        // DB not configured yet -- that's fine, just skip
+      }
+    }
+
     /**
      * Since context is not sent along with individual user messages, it's necessary to keep
      * track of the context of the conversation to better assist the user. Sending an initial
@@ -23,7 +39,31 @@ export const assistantThreadStarted: AssistantThreadStartedMiddleware = async ({
      * The `say` utility sends this metadata along automatically behind the scenes.
      * !! Please note: this is only intended for development and demonstrative purposes.
      */
-    await say("Hi, how can I help?");
+    if (!hasMcpToken && process.env.SLACK_CLIENT_ID) {
+      const baseUrl =
+        process.env.SLACK_OAUTH_REDIRECT_URL?.replace(/\/$/, "") ||
+        (process.env.VERCEL_PROJECT_PRODUCTION_URL
+          ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
+          : process.env.VERCEL_URL
+            ? `https://${process.env.VERCEL_URL}`
+            : "http://localhost:3000");
+      const installUrl = `${baseUrl}/slack/install`;
+
+      await say({
+        text: `Hi, how can I help? For enhanced features like searching messages, files, and users, authorize the app: ${installUrl}`,
+        blocks: [
+          {
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: `Hi, how can I help?\n\nFor enhanced features like searching messages, files, and users, <${installUrl}|authorize the app> to grant MCP access.`,
+            },
+          },
+        ],
+      });
+    } else {
+      await say("Hi, how can I help?");
+    }
 
     await saveThreadContext();
 

--- a/server/listeners/assistant/assistantUserMessage.ts
+++ b/server/listeners/assistant/assistantUserMessage.ts
@@ -3,6 +3,7 @@ import type { ModelMessage } from "ai";
 import { start } from "workflow/api";
 import { chatWorkflow } from "~/lib/ai/workflows/chat";
 import { getClientToken } from "~/lib/slack/client";
+import { getUserToken } from "~/lib/slack/installation-store";
 import { getThreadContextAsModelMessage } from "~/lib/slack/utils";
 
 export const assistantUserMessage: AssistantUserMessageMiddleware = async ({
@@ -40,6 +41,17 @@ export const assistantUserMessage: AssistantUserMessageMiddleware = async ({
   // Determine if this is a DM (channel type starts with 'D')
   const is_dm = channel.startsWith("D");
 
+  // Look up the user's MCP OAuth token from the database
+  let userToken: string | undefined;
+  if (userId && teamId) {
+    try {
+      const token = await getUserToken(teamId, userId);
+      if (token) userToken = token;
+    } catch (err) {
+      logger.warn("Failed to look up user MCP token:", err);
+    }
+  }
+
   let messages: ModelMessage[] = [];
   try {
     messages = await getThreadContextAsModelMessage({
@@ -59,6 +71,7 @@ export const assistantUserMessage: AssistantUserMessageMiddleware = async ({
         team_id: teamId ?? "", // The workspace team_id for API calls
         bot_id: botId,
         token: getClientToken(client),
+        userToken,
       },
     ]);
 

--- a/server/routes/slack/install.get.ts
+++ b/server/routes/slack/install.get.ts
@@ -1,0 +1,22 @@
+import { generateOAuthState, getInstallUrl } from "~/lib/slack/oauth";
+
+/**
+ * GET /slack/install
+ *
+ * Initiates the Slack OAuth flow by redirecting to Slack's authorization page.
+ * This grants the app user-level scopes needed for MCP tools.
+ */
+export default defineEventHandler((event) => {
+  const { state } = generateOAuthState();
+
+  // Store state in a short-lived cookie for CSRF verification on callback
+  setCookie(event, "slack_oauth_state", state, {
+    httpOnly: true,
+    secure: true,
+    sameSite: "lax",
+    maxAge: 600, // 10 minutes
+    path: "/",
+  });
+
+  return sendRedirect(event, getInstallUrl(state));
+});

--- a/server/routes/slack/oauth_redirect.get.ts
+++ b/server/routes/slack/oauth_redirect.get.ts
@@ -1,0 +1,87 @@
+import { verifyOAuthState, exchangeCodeForToken } from "~/lib/slack/oauth";
+import { storeInstallation } from "~/lib/slack/installation-store";
+
+/**
+ * GET /slack/oauth_redirect
+ *
+ * Handles the OAuth callback from Slack after user authorization.
+ * Exchanges the code for tokens and stores the installation in the database.
+ */
+export default defineEventHandler(async (event) => {
+  const query = getQuery(event);
+  const code = query.code as string | undefined;
+  const state = query.state as string | undefined;
+  const error = query.error as string | undefined;
+
+  // Handle user cancellation
+  if (error) {
+    return sendRedirect(
+      event,
+      `/slack/install/error?message=${encodeURIComponent(error)}`
+    );
+  }
+
+  // Validate required parameters
+  if (!code || !state) {
+    setResponseStatus(event, 400);
+    return { error: "Missing code or state parameter" };
+  }
+
+  // Verify the state parameter matches what we set in the cookie
+  const storedState = getCookie(event, "slack_oauth_state");
+  if (!storedState || storedState !== state || !verifyOAuthState(state)) {
+    setResponseStatus(event, 403);
+    return { error: "Invalid or expired OAuth state" };
+  }
+
+  // Clear the state cookie
+  deleteCookie(event, "slack_oauth_state", { path: "/" });
+
+  try {
+    const result = await exchangeCodeForToken(code);
+
+    if (!result.ok || !result.authed_user) {
+      setResponseStatus(event, 400);
+      return {
+        error: "OAuth token exchange failed",
+        detail: result.error ?? "No authed_user in response",
+      };
+    }
+
+    const { authed_user, team, enterprise, app_id } = result;
+
+    if (!team?.id) {
+      setResponseStatus(event, 400);
+      return { error: "No team ID in OAuth response" };
+    }
+
+    // Store the installation in the database
+    await storeInstallation({
+      teamId: team.id,
+      userId: authed_user.id,
+      userToken: authed_user.access_token,
+      userScopes: authed_user.scope,
+      appId: app_id,
+      enterpriseId: enterprise?.id,
+      tokenType: authed_user.token_type,
+    });
+
+    // Return a simple success page
+    return `
+      <!DOCTYPE html>
+      <html>
+        <head><title>Installation Complete</title></head>
+        <body style="font-family: system-ui, sans-serif; display: flex; align-items: center; justify-content: center; min-height: 100vh; margin: 0; background: #f8f9fa;">
+          <div style="text-align: center; max-width: 400px; padding: 2rem;">
+            <h1 style="font-size: 1.5rem; margin-bottom: 0.5rem;">Installation Complete</h1>
+            <p style="color: #666;">You can now close this window and return to Slack. The agent now has access to enhanced MCP tools on your behalf.</p>
+          </div>
+        </body>
+      </html>
+    `;
+  } catch (err) {
+    console.error("OAuth callback error:", err);
+    setResponseStatus(event, 500);
+    return { error: "Internal server error during OAuth callback" };
+  }
+});


### PR DESCRIPTION
The Slack MCP integration previously relied on a single static `SLACK_MCP_USER_TOKEN` env var. Slack's MCP server requires per-user OAuth tokens so tools operate on behalf of the invoking user with their permissions. This adds a complete OAuth flow using Neon PostgreSQL (via Drizzle ORM) for token storage.

### What changed

- Added `@neondatabase/serverless` and `drizzle-orm` for database access, with a `slack_installations` table schema keyed by `(team_id, user_id)`
- Created `server/lib/slack/oauth.ts` with CSRF-protected state generation, Slack OAuth URL building, and token exchange via `oauth.v2.access`
- Added two Nitro routes: `GET /slack/install` (redirects to Slack authorization) and `GET /slack/oauth_redirect` (handles callback, stores tokens)
- Created `server/lib/slack/installation-store.ts` with Drizzle-backed `getUserToken`, `storeInstallation`, and `deleteInstallation`
- Updated `assistantUserMessage` to look up the user's token from the DB and pass it through context to the workflow
- Updated `assistantThreadStarted` to show an "authorize the app" link when the user hasn't completed the OAuth flow
- Updated `mcp.ts` to accept a `userToken` parameter instead of reading from env, and `chat.ts` to use `context.userToken`
- Updated `manifest.json` with user scopes and redirect URL placeholder
- Added `.env.example` with the new required variables (`SLACK_CLIENT_ID`, `SLACK_CLIENT_SECRET`, `SLACK_STATE_SECRET`, `DATABASE_URL`)

### How to test
1. Set up a Neon database and run `pnpm db:push` to create the schema
2. Add `SLACK_CLIENT_ID`, `SLACK_CLIENT_SECRET`, `SLACK_STATE_SECRET`, and `DATABASE_URL` to your env
3. Update your Slack app's redirect URL to `https://your-domain/slack/oauth_redirect`
4. Open the assistant -- users without tokens see an authorize link; after authorizing, MCP tools are available

<a href="https://vercel.slack.com/archives/C06S42QMC6M/p1771438573566969?thread_ts=1771438573.566969&cid=C06S42QMC6M"><picture><source media="(prefers-color-scheme: dark)" srcset="https://v0.app/chat-static/slack-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://v0.app/chat-static/slack-light.svg"><img alt="Slack Thread" src="https://v0.app/chat-static/slack-light.svg" width="108" height="30"></picture></a>