### PR TITLE
Deprecate repo and redirect to Eve Slack Agent template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Slack Agent Template
 
-[![Deploy with Vercel](https://vercel.com/button)](<https://vercel.com/new/clone?demo-description=This%20is%20a%20Slack%20Agent%20template%20built%20with%20Bolt%20for%20JavaScript%20(TypeScript)%20and%20the%20Nitro%20server%20framework.&demo-image=%2F%2Fimages.ctfassets.net%2Fe5382hct74si%2FSs9t7RkKlPtProrbDhZFM%2F0d11b9095ecf84c87a68fbdef6f12ad1%2FFrame__1_.png&demo-title=Slack%20Agent%20Template&demo-url=https%3A%2F%2Fgithub.com%2Fvercel-partner-solutions%2Fslack-agent-template&env=SLACK_SIGNING_SECRET%2CSLACK_BOT_TOKEN&envDescription=These%20environment%20variables%20are%20required%20to%20deploy%20your%20Slack%20app%20to%20Vercel&envLink=https%3A%2F%2Fapi.slack.com%2Fapps&from=templates&project-name=Slack%20Agent%20Template&project-names=Comma%20separated%20list%20of%20project%20names%2Cto%20match%20the%20root-directories&repository-name=slack-agent-template&repository-url=https%3A%2F%2Fgithub.com%2Fvercel-partner-solutions%2Fslack-agent-template&root-directories=List%20of%20directory%20paths%20for%20the%20directories%20to%20clone%20into%20projects&skippable-integrations=1>)
+> [!WARNING]
+> **This repository is deprecated and no longer maintained.**
+>
+> Please use the official template instead: **[Eve Slack Agent](https://vercel.com/templates/eve/eve-slack-agent)**.
+>
+> The documentation below is preserved for reference only.
 
 A Slack Agent template built with [Workflow DevKit](https://useworkflow.dev)'s `DurableAgent`, [AI SDK](https://ai-sdk.dev) tools, [Bolt for JavaScript](https://tools.slack.dev/bolt-js/) (TypeScript), and the [Nitro](https://nitro.build) server framework.
 


### PR DESCRIPTION
Deprecates this repository in favor of the official [Eve Slack Agent template](https://vercel.com/templates/eve/eve-slack-agent).

## Changes
- Add a deprecation `[!WARNING]` notice at the top of the README pointing to the new template
- Remove the "Deploy with Vercel" button so the deprecated template isn't cloned

## Follow-up (outside this PR)
- Update repo description/topics to flag deprecation
- Archive the repository (read-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)